### PR TITLE
Update deployment target from burr to azul.tailnet-003a.ts.net

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           RSYNC_PASSWORD: ${{ secrets.RSYNC_PASSWORD }}
         run: |
-          rsync -avz --delete ./www/ rsync://wwwdeploy@burr.tailnet-003a.ts.net/fuckingtimezones.com/
+          rsync -avz --delete ./www/ rsync://wwwdeploy@azul.cdzombak.net/fuckingtimezones.com/
 
   ntfy:
     name: Ntfy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           RSYNC_PASSWORD: ${{ secrets.RSYNC_PASSWORD }}
         run: |
-          rsync -avz --delete ./www/ rsync://wwwdeploy@azul.cdzombak.net/fuckingtimezones.com/
+          rsync -avz --delete ./www/ rsync://wwwdeploy@azul.tailnet-003a.ts.net/fuckingtimezones.com/
 
   ntfy:
     name: Ntfy


### PR DESCRIPTION
# Update deployment target from burr to azul.tailnet-003a.ts.net

## Summary
Updates the rsync deployment target hostname from `burr.tailnet-003a.ts.net` to `azul.tailnet-003a.ts.net` in the GitHub Actions deploy workflow. This migrates the deployment destination to the new server while keeping all other configuration (module path `/fuckingtimezones.com/`, authentication, Tailscale setup) unchanged.

This is part of a coordinated migration across 8 repositories. Four have already been successfully migrated and merged: 10foot6in, arborwx-static, clock, and computers.ninja.

## Review & Testing Checklist for Human
- [ ] Verify `azul.tailnet-003a.ts.net` has the rsync daemon running and properly configured with the `/fuckingtimezones.com/` module path matching the old burr setup
- [ ] Confirm the `RSYNC_PASSWORD` secret in this repo's GitHub settings is valid for authenticating to azul's rsync daemon
- [ ] Check that Tailscale ACLs permit GitHub Actions runners (using the `TS_OAUTH_CLIENT_ID`/`TS_OAUTH_SECRET`) to access azul.tailnet-003a.ts.net
- [ ] After merge, monitor the next deployment to main branch to verify files actually deploy successfully to azul and the site remains accessible

### Notes
- The workflow only runs on push to main, so this cannot be tested until after merge
- Once merged, the next commit to main will trigger a deployment to the new server
- If azul isn't fully configured, deployments will fail but can be fixed by updating the server configuration

Link to Devin run: https://app.devin.ai/sessions/77c390486c6e4c368a9f2e486d472c0e  
Requested by: Chris Dzombak (chris@dzombak.com) / @cdzombak

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to target a new synchronization endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->